### PR TITLE
fix jp4 jumper conections for m50

### DIFF
--- a/m50,m40,m60 Pnp/Jumper configurations.txt
+++ b/m50,m40,m60 Pnp/Jumper configurations.txt
@@ -11,14 +11,14 @@ For M50NV Connect: 3,5,9,11,14,18,19,20,28,29, JP21:1-2, JP22:2-3, JP4:2-3
 For M50TU Connect: 1,3,5,9,11,14,18,19,20,28,29,30, JP31:1-2, JP21:2-3, JP22:1-2, JP4:1-2
 For M4x Connect: 8,15,16,17,26,27, JP21:1-2, JP22:2-3, JP4:2-3
 For M60 Connect: 1,2,6,7,10,11,12,13,14,25,28,29, JP21:2-3, JP22:1-2, JP4:2-3 (note that it's recommended to not connect knock sensors with m60)
-For M50NV seqvential Connect: 6,10,11,14,28,29, JP21:1-2, JP22:2-3, JP4:2-3
-For M50TU seqvential Connect: 1,6,10,11,14,28,29,30, JP31:1-2, JP21:2-3, JP22:1-2, JP4:1-2
+For M50NV seqvential Connect: 6,10,11,14,28,29, JP21:1-2, JP22:2-3, JP4:1-2
+For M50TU seqvential Connect: 1,6,10,11,14,28,29,30, JP31:1-2, JP21:2-3, JP22:1-2, JP4:2-3
 
 Rev 2.1:
 For M4x Connect: 3,8,15,16,17,26,27, JP21:1-2, JP22:2-3, JP4:2-3
 For M60 Connect: 1,2,6,7,10,11,12,13,14,25,28,29, JP21:2-3, JP22:1-2, JP4:2-3 (note that it's recommended to not connect knock sensors with m60)
-For M50NV Connect: 3,6,10,11,14,28,29, JP21:1-2, JP22:2-3, JP4:2-3
-For M50TU Connect: 1,6,10,11,14,28,29,30, JP31:1-2, JP21:2-3, JP22:1-2, JP4:1-2
+For M50NV Connect: 3,6,10,11,14,28,29, JP21:1-2, JP22:2-3, JP4:1-2
+For M50TU Connect: 1,6,10,11,14,28,29,30, JP31:1-2, JP21:2-3, JP22:1-2, JP4:2-3
 
 Using hall type sensors instead of stock vr:
 


### PR DESCRIPTION
Investigated jumper connections in https://easyeda.com/editor#id=fb16afdb71434bf79588f97456e4c3c4
and I think I've found a mistake in m50nv & m50tu jp4 jumper configuration.

Here is DME 3.1 44 pin documentation :
![p44_M50nv](https://user-images.githubusercontent.com/9460698/99122080-56a14180-2606-11eb-82e3-9d1b5cc20fff.png)
 

Here is DME 3.3.1 44 pin documentation:
![p44_M50tu](https://user-images.githubusercontent.com/9460698/99122174-851f1c80-2606-11eb-9daa-11df94009496.png)


Here are screenshots with pin numbers in easyeda:
![rev2 1_jp4_pin1](https://user-images.githubusercontent.com/9460698/99122451-05458200-2607-11eb-81e6-c043d0e83b45.png)
![rev2 1_jp4_pin3](https://user-images.githubusercontent.com/9460698/99122490-15f5f800-2607-11eb-8f17-ef9418f1b295.png)

